### PR TITLE
Implement missing cases in GetPE32DataW_impl

### DIFF
--- a/StaticEngine/Emulator.h
+++ b/StaticEngine/Emulator.h
@@ -548,7 +548,7 @@ public:
         case UE_SECTIONNAME:
             return WhichSection < sections.size() ? ULONG_PTR(&sections.at(WhichSection).GetHeader().Name[0]) : 0;
         case UE_IMAGEBASE:
-            return headers->OptionalHeader.ImageBase;
+            return (ULONG_PTR)headers->OptionalHeader.ImageBase;
         case UE_SIZEOFIMAGE:
             return headers->OptionalHeader.SizeOfImage;
         case UE_RELOCATIONTABLEADDRESS:
@@ -559,6 +559,14 @@ public:
             return headers->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_TLS].VirtualAddress;
         case UE_TLSTABLESIZE:
             return headers->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_TLS].Size;
+        case UE_TIMEDATESTAMP:
+            return headers->FileHeader.TimeDateStamp;
+        case UE_CHECKSUM:
+            return headers->OptionalHeader.CheckSum;
+        case UE_SUBSYSTEM:
+            return headers->OptionalHeader.Subsystem;
+        case UE_NUMBEROFRVAANDSIZES:
+            return headers->OptionalHeader.NumberOfRvaAndSizes;
         default:
             __debugbreak();
         }

--- a/TitanEngineEmulator/Emulator.h
+++ b/TitanEngineEmulator/Emulator.h
@@ -612,7 +612,7 @@ public:
         case UE_SECTIONNAME:
             return WhichSection < sections.size() ? ULONG_PTR(&sections.at(WhichSection).GetHeader().Name[0]) : 0;
         case UE_IMAGEBASE:
-            return headers->OptionalHeader.ImageBase;
+            return (ULONG_PTR)headers->OptionalHeader.ImageBase;
         case UE_SIZEOFIMAGE:
             return headers->OptionalHeader.SizeOfImage;
         case UE_RELOCATIONTABLEADDRESS:
@@ -623,6 +623,14 @@ public:
             return headers->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_TLS].VirtualAddress;
         case UE_TLSTABLESIZE:
             return headers->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_TLS].Size;
+        case UE_TIMEDATESTAMP:
+            return headers->FileHeader.TimeDateStamp;
+        case UE_CHECKSUM:
+            return headers->OptionalHeader.CheckSum;
+        case UE_SUBSYSTEM:
+            return headers->OptionalHeader.Subsystem;
+        case UE_NUMBEROFRVAANDSIZES:
+            return headers->OptionalHeader.NumberOfRvaAndSizes;
         default:
             __debugbreak();
         }


### PR DESCRIPTION
Ran into an assert/`__debugbreak()` because `GetPE32DataW_impl` didn't know how to handle `UE_SUBSYSTEM`. Implemented this and the other missing cases.

Btw: the cast to `ULONG_PTR` for `UE_IMAGEBASE` is only to silence a compiler warning on x86.