### PR TITLE
Emulator: implement StaticFileLoad and GetPE32Data

### DIFF
--- a/GleeBug/GleeBug.vcxproj
+++ b/GleeBug/GleeBug.vcxproj
@@ -171,6 +171,7 @@
     <ClCompile Include="Static.File.cpp" />
     <ClCompile Include="Static.Pattern.cpp" />
     <ClCompile Include="Static.Pe.cpp" />
+    <ClCompile Include="stringutils.cpp" />
     <ClCompile Include="zyan-disassembler-engine\src\Decoder.c" />
     <ClCompile Include="zyan-disassembler-engine\src\Formatter.c">
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">_CRT_SECURE_NO_WARNINGS;_USING_V110_SDK71_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -203,6 +204,7 @@
     <ClInclude Include="Static.Pe.h" />
     <ClInclude Include="Static.Pe.Section.h" />
     <ClInclude Include="Static.Region.h" />
+    <ClInclude Include="stringutils.h" />
     <ClInclude Include="zyan-disassembler-engine\include\Zydis\Decoder.h" />
     <ClInclude Include="zyan-disassembler-engine\include\Zydis\Defines.h" />
     <ClInclude Include="zyan-disassembler-engine\include\Zydis\Formatter.h" />

--- a/GleeBug/GleeBug.vcxproj.filters
+++ b/GleeBug/GleeBug.vcxproj.filters
@@ -104,6 +104,9 @@
     <ClCompile Include="zyan-disassembler-engine\src\Zydis.c">
       <Filter>Source Files\Zydis</Filter>
     </ClCompile>
+    <ClCompile Include="stringutils.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Debugger.h">
@@ -191,6 +194,9 @@
       <Filter>Header Files\Zydis</Filter>
     </ClInclude>
     <ClInclude Include="oprintf.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="stringutils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/StaticEngine/Emulator.h
+++ b/StaticEngine/Emulator.h
@@ -5,7 +5,8 @@
 #include "ntdll.h"
 #include "FileMap.h"
 #include <GleeBug/Static.Pe.h>
-#include <GleeBug/Static.Bufferfile.h>
+#include <GleeBug/Static.BufferFile.h>
+#include <GleeBug/stringutils.h>
 
 #pragma comment(lib, "psapi.lib")
 
@@ -467,6 +468,11 @@ public:
     std::unordered_map<ULONG_PTR, MappedPe> mappedFiles;
 
     //PE
+    bool StaticFileLoad(const char* szFileName, DWORD DesiredAccess, bool SimulateLoad, LPHANDLE FileHandle, LPDWORD LoadedSize, LPHANDLE FileMap, PULONG_PTR FileMapVA)
+    {
+        return StaticFileLoadW(Utf8ToUtf16(szFileName).c_str(), DesiredAccess, SimulateLoad, FileHandle, LoadedSize, FileMap, FileMapVA);
+    }
+
     bool StaticFileLoadW(const wchar_t* szFileName, DWORD DesiredAccess, bool SimulateLoad, LPHANDLE FileHandle, LPDWORD LoadedSize, LPHANDLE FileMap, PULONG_PTR FileMapVA)
     {
         auto file = new ::FileMap<unsigned char>;
@@ -592,6 +598,11 @@ public:
         return found->second.pe->IsPe64()
             ? GetPE32DataW_impl(found->second.pe->GetNtHeaders64(), WhichSection, WhichData, sections)
             : GetPE32DataW_impl(found->second.pe->GetNtHeaders32(), WhichSection, WhichData, sections);
+    }
+
+    ULONG_PTR GetPE32Data(const char* szFileName, DWORD WhichSection, DWORD WhichData)
+    {
+        return GetPE32DataW(Utf8ToUtf16(szFileName).c_str(), WhichSection, WhichData);
     }
 
     ULONG_PTR GetPE32DataW(const wchar_t* szFileName, DWORD WhichSection, DWORD WhichData)

--- a/StaticEngine/TitanEngineEmulator.cpp
+++ b/StaticEngine/TitanEngineEmulator.cpp
@@ -1,4 +1,4 @@
-#include <windows.h>
+#include <Windows.h>
 #include "Emulator.h"
 
 Emulator emu;
@@ -172,6 +172,11 @@ __declspec(dllexport) void TITCALL Getx87FPURegisters(x87FPURegister_t x87FPUReg
 }
 
 //PE
+__declspec(dllexport) bool TITCALL StaticFileLoad(const char* szFileName, DWORD DesiredAccess, bool SimulateLoad, LPHANDLE FileHandle, LPDWORD LoadedSize, LPHANDLE FileMap, PULONG_PTR FileMapVA)
+{
+    return emu.StaticFileLoad(szFileName, DesiredAccess, SimulateLoad, FileHandle, LoadedSize, FileMap, FileMapVA);
+}
+
 __declspec(dllexport) bool TITCALL StaticFileLoadW(const wchar_t* szFileName, DWORD DesiredAccess, bool SimulateLoad, LPHANDLE FileHandle, LPDWORD LoadedSize, LPHANDLE FileMap, PULONG_PTR FileMapVA)
 {
     return emu.StaticFileLoadW(szFileName, DesiredAccess, SimulateLoad, FileHandle, LoadedSize, FileMap, FileMapVA);
@@ -200,6 +205,11 @@ __declspec(dllexport) ULONG_PTR TITCALL ConvertVAtoFileOffsetEx(ULONG_PTR FileMa
 __declspec(dllexport) ULONG_PTR TITCALL GetPE32DataFromMappedFile(ULONG_PTR FileMapVA, DWORD WhichSection, DWORD WhichData)
 {
     return emu.GetPE32DataFromMappedFile(FileMapVA, WhichSection, WhichData);
+}
+
+__declspec(dllexport) ULONG_PTR TITCALL GetPE32Data(const char* szFileName, DWORD WhichSection, DWORD WhichData)
+{
+    return emu.GetPE32Data(szFileName, WhichSection, WhichData);
 }
 
 __declspec(dllexport) ULONG_PTR TITCALL GetPE32DataW(const wchar_t* szFileName, DWORD WhichSection, DWORD WhichData)

--- a/TitanEngineEmulator/Emulator.h
+++ b/TitanEngineEmulator/Emulator.h
@@ -2,6 +2,7 @@
 #include <GleeBug/Static.Pe.h>
 #include <GleeBug/Static.Bufferfile.h>
 #include <GleeBug/Debugger.Thread.Registers.h>
+#include <GleeBug/stringutils.h>
 #include "TitanEngine.h"
 #include "FileMap.h"
 #include "PEB.h"
@@ -531,6 +532,11 @@ public:
     std::unordered_map<ULONG_PTR, MappedPe> mappedFiles;
 
     //PE
+    bool StaticFileLoad(const char* szFileName, DWORD DesiredAccess, bool SimulateLoad, LPHANDLE FileHandle, LPDWORD LoadedSize, LPHANDLE FileMap, PULONG_PTR FileMapVA)
+    {
+        return StaticFileLoadW(Utf8ToUtf16(szFileName).c_str(), DesiredAccess, SimulateLoad, FileHandle, LoadedSize, FileMap, FileMapVA);
+    }
+
     bool StaticFileLoadW(const wchar_t* szFileName, DWORD DesiredAccess, bool SimulateLoad, LPHANDLE FileHandle, LPDWORD LoadedSize, LPHANDLE FileMap, PULONG_PTR FileMapVA)
     {
         auto file = new ::FileMap<unsigned char>;
@@ -653,6 +659,11 @@ public:
         return found->second.pe->IsPe64()
             ? GetPE32DataW_impl(found->second.pe->GetNtHeaders64(), WhichSection, WhichData, sections)
             : GetPE32DataW_impl(found->second.pe->GetNtHeaders32(), WhichSection, WhichData, sections);
+    }
+
+    ULONG_PTR GetPE32Data(const char* szFileName, DWORD WhichSection, DWORD WhichData)
+    {
+        return GetPE32DataW(Utf8ToUtf16(szFileName).c_str(), WhichSection, WhichData);
     }
 
     ULONG_PTR GetPE32DataW(const wchar_t* szFileName, DWORD WhichSection, DWORD WhichData)

--- a/TitanEngineEmulator/TitanEngineEmulator.cpp
+++ b/TitanEngineEmulator/TitanEngineEmulator.cpp
@@ -172,6 +172,11 @@ __declspec(dllexport) void TITCALL Getx87FPURegisters(x87FPURegister_t x87FPUReg
 }
 
 //PE
+__declspec(dllexport) bool TITCALL StaticFileLoad(const char* szFileName, DWORD DesiredAccess, bool SimulateLoad, LPHANDLE FileHandle, LPDWORD LoadedSize, LPHANDLE FileMap, PULONG_PTR FileMapVA)
+{
+    return emu.StaticFileLoad(szFileName, DesiredAccess, SimulateLoad, FileHandle, LoadedSize, FileMap, FileMapVA);
+}
+
 __declspec(dllexport) bool TITCALL StaticFileLoadW(const wchar_t* szFileName, DWORD DesiredAccess, bool SimulateLoad, LPHANDLE FileHandle, LPDWORD LoadedSize, LPHANDLE FileMap, PULONG_PTR FileMapVA)
 {
     return emu.StaticFileLoadW(szFileName, DesiredAccess, SimulateLoad, FileHandle, LoadedSize, FileMap, FileMapVA);
@@ -200,6 +205,11 @@ __declspec(dllexport) ULONG_PTR TITCALL ConvertVAtoFileOffsetEx(ULONG_PTR FileMa
 __declspec(dllexport) ULONG_PTR TITCALL GetPE32DataFromMappedFile(ULONG_PTR FileMapVA, DWORD WhichSection, DWORD WhichData)
 {
     return emu.GetPE32DataFromMappedFile(FileMapVA, WhichSection, WhichData);
+}
+
+__declspec(dllexport) ULONG_PTR TITCALL GetPE32Data(const char* szFileName, DWORD WhichSection, DWORD WhichData)
+{
+    return emu.GetPE32Data(szFileName, WhichSection, WhichData);
 }
 
 __declspec(dllexport) ULONG_PTR TITCALL GetPE32DataW(const wchar_t* szFileName, DWORD WhichSection, DWORD WhichData)


### PR DESCRIPTION
See title.

I accidentally forgot to commit the `.vcxproj` files for the `stringutils.cpp` addition in my last commit, so that is in here too.