### PR TITLE
ConvertVAtoFileOffsetEx() fails on VA's and crashes client

### DIFF
--- a/StaticEngine/Emulator.h
+++ b/StaticEngine/Emulator.h
@@ -503,33 +503,92 @@ public:
         mappedFiles.erase(found);
         return true;
     }
-
-    ULONG_PTR ConvertFileOffsetToVA(ULONG_PTR FileMapVA, ULONG_PTR AddressToConvert, bool ReturnType)
+    ////
+    ///
+    // ConvertFileOffsetToVA   -   converts FileOffset to a virtual addresses
+    //                              checks if PE file is valid and if memory is accessible
+    // Returns: converted VA
+    //          or NULL if conversion has failed.
+    //
+    ULONG_PTR ConvertFileOffsetToVA(
+        ULONG_PTR FileMapVA,        // [in] Pointer to the mapped file content. It's either StaticFileLoad function or Windows API for file mapping.
+        ULONG_PTR AddressToConvert, // [in] physical address/file offset
+        bool ReturnType             // [in] if true: add the FileMapVA to the return value
+    )
     {
         auto found = mappedFiles.find(FileMapVA);
         if (found == mappedFiles.end())
             __debugbreak(); //return 0;
+
         if (!found->second.pe->IsValidPe())
             __debugbreak(); //return 0;
-        return found->second.pe->ConvertOffsetToRva(uint32(AddressToConvert));
-    }
 
-    ULONG_PTR ConvertVAtoFileOffset(ULONG_PTR FileMapVA, ULONG_PTR AddressToConvert, bool ReturnType)
-    {
-        return ConvertVAtoFileOffsetEx(FileMapVA, 0, 0, AddressToConvert, false, ReturnType);
-    }
+        // convert:  FileOffset -> VA
+        auto offset =   found->second.pe->ConvertOffsetToRva(
+                            uint32( AddressToConvert )
+                        );
 
-    ULONG_PTR ConvertVAtoFileOffsetEx(ULONG_PTR FileMapVA, DWORD FileSize, ULONG_PTR ImageBase, ULONG_PTR AddressToConvert, bool AddressIsRVA, bool ReturnType)
-    {
-        auto found = mappedFiles.find(FileMapVA);
-        if (found == mappedFiles.end())
-            __debugbreak(); //return 0;
-        if (!found->second.pe->IsValidPe())
-            __debugbreak(); //return 0;
-        auto offset = found->second.pe->ConvertRvaToOffset(uint32(AddressToConvert));
         if (offset == INVALID_VALUE)
-            return 0;
-        return ReturnType ? FileMapVA + offset : offset;
+            return 0
+        else
+            return ReturnType ? FileMapVA + offset : offset;
+    }
+
+    ////
+    ///
+    // ConvertVAtoFileOffset    -   converts virtual addresses to its physical counterpart.
+    //
+    // Returns: converted physical address
+    //          or NULL if conversion has failed.
+    //
+    ULONG_PTR ConvertVAtoFileOffset(
+        ULONG_PTR FileMapVA,        // [in] Pointer to the mapped file content. It's either StaticFileLoad function or Windows API for file mapping.
+        ULONG_PTR AddressToConvert, // [in] Virtual address to convert to a physical address.
+        bool ReturnType             // [in] if true: add the FileMapVA to the return value
+    )
+    {
+        return ConvertVAtoFileOffsetEx(
+                    FileMapVA ,0 ,0 ,
+                    AddressToConvert, false, ReturnType );
+    }
+
+    ////
+    ///
+    // ConvertVAtoFileOffsetEx  -   converts virtual addresses to its physical counterpart.
+    //                              checks if PE file is valid and if memory is accessible
+    // Returns: converted physical address
+    //          or NULL if conversion has failed.
+    //
+    ULONG_PTR ConvertVAtoFileOffsetEx(
+        ULONG_PTR FileMapVA,        // [in] Pointer to the mapped file content. It's either StaticFileLoad function or Windows API for file mapping.
+        DWORD FileSize,             // [in] Size of the mapped file.
+        ULONG_PTR ImageBase,        // [in] ImageBase of the mapped file
+        ULONG_PTR AddressToConvert, // [in] Virtual address to convert to a physical address.
+        bool AddressIsRVA,          // [in] true => AddressToConvert is relative virtual address
+        bool ReturnType             // [in] if true: add the FileMapVA to the return value
+    )
+    {
+        auto found = mappedFiles.find(FileMapVA);
+        if (found == mappedFiles.end())
+            __debugbreak(); //return 0;
+
+        if (!found->second.pe->IsValidPe())
+            __debugbreak(); //return 0;
+
+        // Convert to RVA if needed
+        auto RVA_ToConvert = AddressIsRVA ?
+                        AddressToConvert :
+                        AddressToConvert - ImageBase;
+
+        // convert:  VA -> FileOffset
+        auto offset =   found->second.pe->ConvertRvaToOffset(
+                            uint32( RVA_ToConvert )
+                        );
+
+        if (offset == INVALID_VALUE)
+            return 0
+        else
+            return ReturnType ? FileMapVA + offset : offset;
     }
 
     template<typename T>

--- a/TitanEngineEmulator/Emulator.h
+++ b/TitanEngineEmulator/Emulator.h
@@ -571,29 +571,71 @@ public:
     ULONG_PTR ConvertFileOffsetToVA(ULONG_PTR FileMapVA, ULONG_PTR AddressToConvert, bool ReturnType)
     {
         auto found = mappedFiles.find(FileMapVA);
+
         if(found == mappedFiles.end())
             __debugbreak(); //return 0;
+
         if(!found->second.pe->IsValidPe())
             __debugbreak(); //return 0;
-        return found->second.pe->ConvertOffsetToRva(uint32(AddressToConvert));
+
+        auto offset =   found->second.pe->ConvertOffsetToRva( uint32( AddressToConvert ) );
+
+        if (offset == INVALID_VALUE)
+            return 0;
     }
 
-    ULONG_PTR ConvertVAtoFileOffset(ULONG_PTR FileMapVA, ULONG_PTR AddressToConvert, bool ReturnType)
+    ////
+    ///
+    // ConvertVAtoFileOffset    -   converts virtual addresses to its physical counterpart.
+    //
+    // Returns: converted physical address
+    //          or NULL if conversion has failed.
+    //
+    ULONG_PTR ConvertVAtoFileOffset(
+        ULONG_PTR FileMapVA,        // [in] Pointer to the mapped file content. It's either StaticFileLoad function or Windows API for file mapping.
+        ULONG_PTR AddressToConvert, // [in] Virtual address to convert to a physical address.
+        bool ReturnType             // [in] Add the FileMapVA return value?
+    )
     {
-        return ConvertVAtoFileOffsetEx(FileMapVA, 0, 0, AddressToConvert, false, ReturnType);
+        return ConvertVAtoFileOffsetEx(
+                    FileMapVA ,0 ,0 , 
+                    AddressToConvert, false, ReturnType );
     }
 
-    ULONG_PTR ConvertVAtoFileOffsetEx(ULONG_PTR FileMapVA, DWORD FileSize, ULONG_PTR ImageBase, ULONG_PTR AddressToConvert, bool AddressIsRVA, bool ReturnType)
+    ////
+    ///
+    // ConvertVAtoFileOffsetEx  -   converts virtual addresses to its physical counterpart.
+    //                              checks if PE file is valid and if memory is accessible
+    // Returns: converted physical address
+    //          or NULL if conversion has failed.
+    //
+    ULONG_PTR ConvertVAtoFileOffsetEx(
+        ULONG_PTR FileMapVA,        // [in] Pointer to the mapped file content. It's either StaticFileLoad function or Windows API for file mapping.
+        DWORD FileSize,             // [in] Size of the mapped file.
+        ULONG_PTR ImageBase,        // [in] ImageBase of the mapped file
+        ULONG_PTR AddressToConvert, // [in] Virtual address to convert to a physical address.
+        bool AddressIsRVA,          // [in] true => AddressToConvert is relative virtual address
+        bool ReturnType             // [in] Add the FileMapVA return value?
+    )
     {
         auto found = mappedFiles.find(FileMapVA);
         if(found == mappedFiles.end())
             __debugbreak(); //return 0;
+
         if(!found->second.pe->IsValidPe())
             __debugbreak(); //return 0;
-        auto offset = found->second.pe->ConvertRvaToOffset(uint32(AddressToConvert));
+
+        // Convert to RVA if needed
+        auto RVA_ToConvert = AddressIsRVA ?
+                        AddressToConvert :
+                        AddressToConvert - ImageBase;
+
+        auto offset =   found->second.pe->ConvertRvaToOffset(
+                            uint32( RVA_ToConvert )
+                        );
+
         if (offset == INVALID_VALUE)
             return 0;
-        return ReturnType ? FileMapVA + offset : offset;
     }
 
     template<typename T>

--- a/TitanEngineEmulator/Emulator.h
+++ b/TitanEngineEmulator/Emulator.h
@@ -567,21 +567,35 @@ public:
         mappedFiles.erase(found);
         return true;
     }
-
-    ULONG_PTR ConvertFileOffsetToVA(ULONG_PTR FileMapVA, ULONG_PTR AddressToConvert, bool ReturnType)
+    ////
+    ///
+    // ConvertFileOffsetToVA   -   converts FileOffset to a virtual addresses
+    //                              checks if PE file is valid and if memory is accessible
+    // Returns: converted VA
+    //          or NULL if conversion has failed.
+    //
+    ULONG_PTR ConvertFileOffsetToVA(
+        ULONG_PTR FileMapVA,        // [in] Pointer to the mapped file content. It's either StaticFileLoad function or Windows API for file mapping.
+        ULONG_PTR AddressToConvert, // [in] physical address/file offset
+        bool ReturnType             // [in] if true: add the FileMapVA to the return value
+    )
     {
         auto found = mappedFiles.find(FileMapVA);
-
         if(found == mappedFiles.end())
             __debugbreak(); //return 0;
 
         if(!found->second.pe->IsValidPe())
             __debugbreak(); //return 0;
 
-        auto offset =   found->second.pe->ConvertOffsetToRva( uint32( AddressToConvert ) );
+        // convert:  FileOffset -> VA
+        auto offset =   found->second.pe->ConvertOffsetToRva(
+                            uint32( AddressToConvert )
+                        );
 
         if (offset == INVALID_VALUE)
-            return 0;
+            return 0
+        else
+            return ReturnType ? FileMapVA + offset : offset;
     }
 
     ////
@@ -594,11 +608,11 @@ public:
     ULONG_PTR ConvertVAtoFileOffset(
         ULONG_PTR FileMapVA,        // [in] Pointer to the mapped file content. It's either StaticFileLoad function or Windows API for file mapping.
         ULONG_PTR AddressToConvert, // [in] Virtual address to convert to a physical address.
-        bool ReturnType             // [in] Add the FileMapVA return value?
+        bool ReturnType             // [in] if true: add the FileMapVA to the return value
     )
     {
         return ConvertVAtoFileOffsetEx(
-                    FileMapVA ,0 ,0 , 
+                    FileMapVA ,0 ,0 ,
                     AddressToConvert, false, ReturnType );
     }
 
@@ -615,7 +629,7 @@ public:
         ULONG_PTR ImageBase,        // [in] ImageBase of the mapped file
         ULONG_PTR AddressToConvert, // [in] Virtual address to convert to a physical address.
         bool AddressIsRVA,          // [in] true => AddressToConvert is relative virtual address
-        bool ReturnType             // [in] Add the FileMapVA return value?
+        bool ReturnType             // [in] if true: add the FileMapVA to the return value
     )
     {
         auto found = mappedFiles.find(FileMapVA);
@@ -630,12 +644,15 @@ public:
                         AddressToConvert :
                         AddressToConvert - ImageBase;
 
+        // convert:  VA -> FileOffset
         auto offset =   found->second.pe->ConvertRvaToOffset(
                             uint32( RVA_ToConvert )
                         );
 
         if (offset == INVALID_VALUE)
-            return 0;
+            return 0
+        else
+            return ReturnType ? FileMapVA + offset : offset;
     }
 
     template<typename T>

--- a/TitanEngineEmulator/Emulator.h
+++ b/TitanEngineEmulator/Emulator.h
@@ -590,7 +590,10 @@ public:
             __debugbreak(); //return 0;
         if(!found->second.pe->IsValidPe())
             __debugbreak(); //return 0;
-        return found->second.pe->ConvertRvaToOffset(uint32(AddressToConvert));
+        auto offset = found->second.pe->ConvertRvaToOffset(uint32(AddressToConvert));
+        if (offset == INVALID_VALUE)
+            return 0;
+        return ReturnType ? FileMapVA + offset : offset;
     }
 
     template<typename T>


### PR DESCRIPTION
That PullReq fixed malfunction in ConvertVAtoFileOffsetEx and avoid possible client crashes due to returning an not expected error value.
4 Changes:
1. ConvertVAtoFileOffsetEx() fails when the client pass a VA in the AddressToConvert (and sets AddressIsRVA=false to show it).
   Fix: Added a handler for AddressIsRVA=false that uses the passed Imagebase to turn the VA into a RVA.

2. ConvertVAtoFileOffsetEx() returned INVALID_VALUE on error. But the client expect 0 in case of an error.
    Result: INVALID_VALUE was misinterpreted as file offset was crashed the client when writting to the mem mapped location
    Fix: before returning INVALID_VALUE is turned to 0

3. ConvertFileOffsetToVA() returned INVALID_VALUE on error.... same story as 2.

4. implementing 'ReturnType' for  ConvertVAtoFileOffsetEx & ConvertFileOffsetToVA

TODO: Also mirgate changes to 
https://github.com/x64dbg/GleeBug/blob/c5aed9fcccb9f2161af86cfefe0ef5006e913fc9/StaticEngine/Emulator.h#L507