### PR TITLE
Fix thread suspension when hardware breakpoint is disabled during callback

### DIFF
--- a/GleeBug/Debugger.Loop.Exception.cpp
+++ b/GleeBug/Debugger.Loop.Exception.cpp
@@ -141,6 +141,10 @@ namespace GleeBug
         if(foundCallback != mProcess->breakpointCallbacks.end())
             foundCallback->second(info);
 
+        //if the breakpoint was deleted during callback, clear internal stepping to prevent thread suspension
+        if(mProcess->breakpoints.find({ BreakpointType::Hardware, info.address }) == mProcess->breakpoints.end())
+            mThread->isInternalStepping = false;
+
         //delete the breakpoint if it is singleshoot
         if(info.singleshoot)
             mProcess->DeleteGenericBreakpoint(info);


### PR DESCRIPTION
Other threads remained permanently suspended after hitting a HWBP, disabling it, and pressing Run.

Similar to: https://github.com/x64dbg/TitanEngine/pull/28

When a HWBP is deleted during the callback, `StepInternal()` has already set `isInternalStepping = true`. So, thread suspension happens in the main loop, but since the breakpoint no longer exists to be restored, no single-step exception fires to resume them. The fix checks if the breakpoint was removed during callback and sets `isInternalStepping`, preventing the suspension.