### PR TITLE
Fix hardware breakpoint register index mismatch

### DIFF
--- a/GleeBug/Debugger.Loop.Exception.cpp
+++ b/GleeBug/Debugger.Loop.Exception.cpp
@@ -143,7 +143,10 @@ namespace GleeBug
 
         //if the breakpoint was deleted during callback, clear internal stepping to prevent thread suspension
         if(mProcess->breakpoints.find({ BreakpointType::Hardware, info.address }) == mProcess->breakpoints.end())
+        {
             mThread->isInternalStepping = false;
+            Registers(mThread->hThread, CONTEXT_CONTROL).TrapFlag = false;
+        }
 
         //delete the breakpoint if it is singleshoot
         if(info.singleshoot)

--- a/TitanEngineEmulator/Emulator.h
+++ b/TitanEngineEmulator/Emulator.h
@@ -821,6 +821,10 @@ public:
     {
         if(!mProcess)
             return false;
+        //convert from UE_DRx (11-14) to slot index (0-3)
+        auto slot = (HardwareSlot)(IndexOfRegister - UE_DR0);
+        if((DWORD)slot > 3)
+            return false;
         auto running = mIsRunning;
         if(running)
         {
@@ -828,7 +832,7 @@ public:
                 thread.second->Suspend();
         }
         if(!mProcess->SetHardwareBreakpoint(bpxAddress,
-                                            (HardwareSlot)IndexOfRegister, [bpxCallBack](const BreakpointInfo & info)
+                                            slot, [bpxCallBack](const BreakpointInfo & info)
     {
         (HWBPCALLBACK(bpxCallBack))((const void*)info.address);
         }, hwtypeFromTitan(bpxType), hwsizeFromTitan(bpxSize)))
@@ -843,9 +847,11 @@ public:
 
     bool DeleteHardwareBreakPoint(DWORD IndexOfRegister)
     {
-        if(!mProcess || IndexOfRegister > 3)
+        //convert from UE_DRx (11-14) to slot index (0-3)
+        auto slot = IndexOfRegister - UE_DR0;
+        if(!mProcess || slot > 3)
             return false;
-        auto address = mProcess->hardwareBreakpoints[IndexOfRegister].address;
+        auto address = mProcess->hardwareBreakpoints[slot].address;
         return mProcess->DeleteHardwareBreakpoint(address);
     }
 
@@ -856,7 +862,7 @@ public:
         HardwareSlot slot;
         bool result = mProcess->GetFreeHardwareBreakpointSlot(slot);
         if(result)
-            *RegisterIndex = (DWORD)slot;
+            *RegisterIndex = UE_DR0 + (DWORD)slot;  //UE_DR0-UE_DR3 (11-14), not 0-3
         return result;
     }
 


### PR DESCRIPTION
https://github.com/x64dbg/GleeBug/pull/74 fixes only one part of the original problem. This PR will fully resolve this issue.

The TitanEngine API uses constants `UE_DR0` to `UE_DR3` (values 11-14) for debug register slots, the emulator returned raw indicies 0-3 from `GetUnusedHardwareBreakPointRegister` instead of 11-14, and used the `IndexOfRegister` parameter directly instead of converting from 11-14 to 0-3. Thus, `DeleteHardwareBreakPoint` fails the `IndexOfRegister > 3` validation check and return false without actually clearing the registers.

I simply convert them to what they should be now, and this works fine. Tested by @ru-mii.